### PR TITLE
Add template for upcoming events page.

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -2,13 +2,14 @@
   "entrypoint": "index.html",
   "shell": "src/wvtc-app.html",
   "fragments": [
-    "src/wvtc-sign-in.html",
-    "src/wvtc-profile.html",
-    "src/wvtc-membership.html",
+    "src/wvtc-404.html",
     "src/wvtc-mailing-lists.html",
+    "src/wvtc-membership.html",
+    "src/wvtc-profile.html",
     "src/wvtc-racing.html",
     "src/wvtc-reimbursement.html",
-    "src/wvtc-404.html"
+    "src/wvtc-sign-in.html",
+    "src/wvtc-upcoming-events.html"
   ],
   "sourceGlobs": [
    "src/**/*",

--- a/src/wvtc-app.html
+++ b/src/wvtc-app.html
@@ -170,6 +170,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             attr-for-selected="name"
             role="navigation"
             class="drawer-list">
+          <a name="upcoming-events" href="/upcoming-events" drawer-toggle>
+             <iron-icon icon="event"></iron-icon>
+             <span>Upcoming</span>
+          </a>
           <a name="profile" href="/profile" drawer-toggle>
              <iron-icon icon="account-circle"></iron-icon>
              <span>Profile</span>
@@ -226,6 +230,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               status-known="{{statusKnown}}"
               signed-in="{{signedIn}}">
           </wvtc-sign-in>
+          <wvtc-upcoming-events name="upcoming-events"></wvtc-upcoming-events>
           <wvtc-profile
               name="profile"
               user="[[user]]"

--- a/src/wvtc-upcoming-events.html
+++ b/src/wvtc-upcoming-events.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors.
+Copyright (c) 2016 West Valley Track Club, Inc.
+All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="shared-styles.html">
+
+<dom-module id="wvtc-upcoming-events">
+  <template>
+    <style include="shared-styles"></style>
+
+    <paper-card class="wvtc-card">
+      <div class="card-content">
+        <div class="circle">1</div>
+        <h1>Upcoming Events</h1>
+        <p>Modus commodo minimum eum te, vero utinam assueverit per eu.</p>
+        <p>Ea duis bonorum nec, falli paulo aliquid ei eum.Has at minim mucius aliquam, est id tempor laoreet.Pro saepe pertinax ei, ad pri animal labores suscipiantur.</p>
+      </div>
+    </paper-card>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'wvtc-upcoming-events'
+    });
+  </script>
+</dom-module>

--- a/test/wvtc-upcoming-events.html
+++ b/test/wvtc-upcoming-events.html
@@ -16,28 +16,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
-    <title>Tests</title>
+    <title>wvtc-upcoming-events</title>
 
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../bower_components/web-component-tester/browser.js"></script>
+
+    <!-- Import the element to test -->
+    <link rel="import" href="../src/wvtc-upcoming-events.html">
   </head>
   <body>
+    <test-fixture id="basic">
+      <template>
+        <wvtc-upcoming-events></wvtc-upcoming-events>
+      </template>
+    </test-fixture>
+
     <script>
-      WCT.loadSuites([
-        'wvtc-sign-in.html?dom=shady',
-        'wvtc-sign-in.html?dom=shadow',
-        'wvtc-upcoming-events.html?dom=shady',
-        'wvtc-upcoming-events.html?dom=shadow',
-        'wvtc-profile.html?dom=shady',
-        'wvtc-profile.html?dom=shadow',
-        'wvtc-membership.html?dom=shady',
-        'wvtc-membership.html?dom=shadow',
-        'wvtc-mailing-lists.html?dom=shady',
-        'wvtc-mailing-lists.html?dom=shadow',
-        'wvtc-racing.html?dom=shady',
-        'wvtc-racing.html?dom=shadow',
-        'wvtc-reimbursement.html?dom=shady',
-        'wvtc-reimbursement.html?dom=shadow'
-      ]);
+      suite('wvtc-upcoming-events tests', function() {
+        var home;
+
+        setup(function() {
+          home = fixture('basic');
+        });
+
+        test('Number in circle should be 1', function() {
+          var circle = Polymer.dom(home.root).querySelector('.circle');
+          assert.equal(circle.textContent, '1');
+        })
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Add a simple template for an upcoming events page along with a link from the drawer menu. This contributes to issue #9.