### PR TITLE
Use FirebaseUI with Polymer for authentication

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#^0.10.6",
     "app-route": "PolymerElements/app-route#^0.9.0",
+    "firebaseui": "^1.0.0",
     "iron-collapse": "PolymerElements/iron-collapse#^1.3.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
@@ -16,7 +17,6 @@
     "iron-localstorage": "PolymerElements/iron-localstorage#^1.0.0",
     "iron-media-query": "PolymerElements/iron-media-query#^1.0.0",
     "iron-selector": "PolymerElements/iron-selector#^1.0.0",
-    "login-fire": "^0.1.4",
     "neon-animation": "PolymerElements/neon-animated-pages#^1.2.4",
     "paper-card": "PolymerElements/paper-card#^1.1.4",
     "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^1.5.0",
@@ -28,7 +28,6 @@
     "paper-tooltip": "PolymerElements/paper-tooltip#^1.1.3",
     "polymer": "Polymer/polymer#^1.6.0",
     "polymerfire": "firebase/polymerfire#^0.10.3",
-    "firebaseui": "^1.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "paper-toast": "PolymerElements/paper-toast#^1.3.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^1.1.3",
     "polymer": "Polymer/polymer#^1.6.0",
-    "polymerfire": "firebase/polymerfire#^0.10.3"
+    "polymerfire": "firebase/polymerfire#^0.10.3",
+    "firebaseui": "^1.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/src/wvtc-app.html
+++ b/src/wvtc-app.html
@@ -30,7 +30,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/neon-animation/animations/fade-out-animation.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-tooltip/paper-tooltip.html">
-<link rel="import" href="../bower_components/polymerfire/firebase-app.html">
 <link rel="import" href="wvtc-icons.html">
 <link rel="import" href="wvtc-sign-in.html">
 
@@ -141,13 +140,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
     </style>
-
-    <firebase-app
-        name="wvtc"
-        api-key="AIzaSyBhdjQwxlc8vsrCiGfv372r4nl4DKi_p80"
-        auth-domain="wvtc-demo.firebaseapp.com"
-        database-url="https://wvtc-demo.firebaseio.com">
-    </firebase-app>
 
     <app-location route="{{route}}"></app-location>
     <app-route

--- a/src/wvtc-profile.html
+++ b/src/wvtc-profile.html
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       #profile-image iron-icon {
-        color: var(--primary-text-color);
+        color: var(--primary-color);
         background-color: var(--primary-background-color);
       }
     </style>

--- a/src/wvtc-sign-in.html
+++ b/src/wvtc-sign-in.html
@@ -10,27 +10,41 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../bower_components/login-fire/login-fire.html">
 <link rel="import" href="../bower_components/paper-card/paper-card.html">
 <link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/polymerfire/firebase-app.html">
+<link rel="import" href="../bower_components/polymerfire/firebase-auth.html">
 <link rel="import" href="shared-styles.html">
+
+<script src="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.js"></script>
+<link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.css" />
 
 <dom-module id="wvtc-sign-in">
   <template>
     <style include="shared-styles"></style>
 
+    <firebase-app
+        name="wvtc"
+        api-key="AIzaSyBhdjQwxlc8vsrCiGfv372r4nl4DKi_p80"
+        auth-domain="wvtc-demo.firebaseapp.com"
+        database-url="https://wvtc-demo.firebaseio.com">
+    </firebase-app>
+    <!-- Doesn't appear to support more than one provider. -->
+    <firebase-auth
+        id="auth"
+        app-name="wvtc"
+        user="{{user}}"
+        status-known="{{statusKnown}}"
+        signed-in="{{signedIn}}"
+        provider="google"
+        on-error="handleError">
+    </firebase-auth>
+
     <div class="wvtc-panel">
       <paper-card class="wvtc-card">
         <div class="card-content">
-          <login-fire
-              id="auth"
-              email-password google facebook
-              reverse
-              app-name="wvtc"
-              user="{{user}}"
-              status-known="{{statusKnown}}"
-              signed-in="{{signedIn}}">
-          </login-fire>
+          <!-- ui.start() cannot find this unless it is in index.html. -->
+          <div id="firebaseui-auth-container"></div>
         </div>
       </paper-card>
     </div>
@@ -57,6 +71,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: Boolean,
           notify: true
         }
+      },
+      ready: function() {
+        var uiConfig = {
+          signInSuccessUrl: '/',
+          signInOptions: [
+            // Leave the lines as is for the providers you want to offer your users.
+            firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+            firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+            firebase.auth.EmailAuthProvider.PROVIDER_ID
+          ]
+        };
+
+        // Initialize the FirebaseUI Widget using Firebase.
+        var ui = new firebaseui.auth.AuthUI(this.$.auth.auth);
+        // The start method will wait until the DOM is loaded.
+        ui.start('#firebaseui-auth-container', uiConfig);
       },
       signOut: function() {
         this.$.auth.signOut();

--- a/src/wvtc-sign-in.html
+++ b/src/wvtc-sign-in.html
@@ -16,11 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/polymerfire/firebase-auth.html">
 <link rel="import" href="shared-styles.html">
 
-<script src="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.js"></script>
-<link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.css" />
-
 <dom-module id="wvtc-sign-in">
   <template>
+    <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.css">
     <style include="shared-styles"></style>
 
     <firebase-app
@@ -29,27 +27,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         auth-domain="wvtc-demo.firebaseapp.com"
         database-url="https://wvtc-demo.firebaseio.com">
     </firebase-app>
-    <!-- Doesn't appear to support more than one provider. -->
     <firebase-auth
         id="auth"
         app-name="wvtc"
         user="{{user}}"
         status-known="{{statusKnown}}"
-        signed-in="{{signedIn}}"
-        provider="google"
+        signed-in="{{authSignedIn}}"
         on-error="handleError">
     </firebase-auth>
-
     <div class="wvtc-panel">
-      <paper-card class="wvtc-card">
-        <div class="card-content">
-          <!-- ui.start() cannot find this unless it is in index.html. -->
-          <div id="firebaseui-auth-container"></div>
-        </div>
-      </paper-card>
+      <div id="firebase-auth-ui"></div>
     </div>
   </template>
 
+  <script src="https://cdn.firebase.com/libs/firebaseui/1.0.0/firebaseui.js"></script>
   <script>
     Polymer({
       is: 'wvtc-sign-in',
@@ -69,27 +60,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
         signedIn: {
           type: Boolean,
+          computed: '_computeSignedIn(authSignedIn, user)',
           notify: true
-        }
+        },
+        uiConfig: {
+          type: Object,
+          value: function() {
+            return {
+              signInFlow: 'popup',
+              signInOptions: [
+                firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+                firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+                firebase.auth.EmailAuthProvider.PROVIDER_ID
+              ],
+              callbacks: {
+                signInSuccess: function(currentUser, credential, redirectUrl) {
+                  // Disable redirect since this is a single-page app.
+                  return false;
+                }
+              }
+            };
+          }
+        },
+      },
+      _computeSignedIn: function(authSignedIn, user) {
+        return authSignedIn && user != null;
       },
       ready: function() {
-        var uiConfig = {
-          signInSuccessUrl: '/',
-          signInOptions: [
-            // Leave the lines as is for the providers you want to offer your users.
-            firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-            firebase.auth.FacebookAuthProvider.PROVIDER_ID,
-            firebase.auth.EmailAuthProvider.PROVIDER_ID
-          ]
-        };
-
-        // Initialize the FirebaseUI Widget using Firebase.
-        var ui = new firebaseui.auth.AuthUI(this.$.auth.auth);
-        // The start method will wait until the DOM is loaded.
-        ui.start('#firebaseui-auth-container', uiConfig);
+        this.ui = new firebaseui.auth.AuthUI(this.$.auth.auth);
+        this.ui.start(this.$['firebase-auth-ui'], this.uiConfig);
       },
       signOut: function() {
-        this.$.auth.signOut();
+        self = this;
+        this.$.auth.signOut().then(function(response) {
+          self.ui.start(self.$['firebase-auth-ui'], self.uiConfig);
+        });
       }
     });
   </script>

--- a/test/wvtc-sign-in.html
+++ b/test/wvtc-sign-in.html
@@ -37,13 +37,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         setup(function() {
           signIn = fixture('basic');
-          
-          stub('login-fire', {
-            signOut: function() {}
+
+          stub('firebase-auth', {
+            signOut: function() {
+              return new Promise(function(resolve, reject) {});
+            }
           });
         });
 
-        test('SignOut delegates to auth', function() {
+        test('SignOut delegates to Firebase authentication', function() {
           signIn.signOut();
           expect(signIn.$.auth.signOut.calledOnce);
         });


### PR DESCRIPTION
Replaces the login-fire (third-party) web component with [FirebaseUI](https://github.com/firebase/FirebaseUI-Web).  The latter is not available via a web component, but could be integrated into the wvtc-sign-in web component without too much difficulty.

This provides a more robust sign-in process by:
- Setting the display name for users with email/password sign-in
- Resolving accounts with conflicting email addresses

Contributes to issue #2.