### PR TITLE
Update Firebase configuration to use project wvtc-members

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "cors": "^2.8.1",
     "firebase-admin": "^4.1.2",
-    "firebase-functions": "^0.5",
+    "firebase-functions": "^0.5"
   },
   "private": true
 }

--- a/src/wvtc-sign-in.html
+++ b/src/wvtc-sign-in.html
@@ -24,9 +24,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <firebase-app
         name="wvtc"
-        api-key="AIzaSyBhdjQwxlc8vsrCiGfv372r4nl4DKi_p80"
-        auth-domain="wvtc-demo.firebaseapp.com"
-        database-url="https://wvtc-demo.firebaseio.com">
+        api-key="AIzaSyBTOuIK93EEVc6AiO0_avlsBKDzuN_Hu_U"
+        auth-domain="wvtc-members.firebaseapp.com"
+        database-url="https://wvtc-members.firebaseio.com">
     </firebase-app>
     <firebase-auth
         id="auth"


### PR DESCRIPTION
Updates the Firebase configuration to use wvtc-members instead of wvtc-demo in preparation for going live.  There doesn't seem to be a simple way to configure this outside the source code, unfortunately.

Also, removes an errant comma from package.json that prevents deploying the Cloud Functions.