### PR TITLE
Add component for upcoming Facebook events

### DIFF
--- a/src/shared-styles.html
+++ b/src/shared-styles.html
@@ -8,6 +8,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../bower_components/paper-styles/typography.html">
 <link rel="import" href="../bower_components/polymer/polymer.html">
 
 <!-- shared styles for all views -->

--- a/src/wvtc-facebook-event.html
+++ b/src/wvtc-facebook-event.html
@@ -1,0 +1,117 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors.
+Copyright (c) 2017 West Valley Track Club, Inc.
+All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../bower_components/iron-icons/maps-icons.html">
+<link rel="import" href="../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../bower_components/paper-item/paper-icon-item.html">
+<link rel="import" href="../bower_components/paper-item/paper-item-body.html">
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="shared-styles.html">
+
+<dom-module id="wvtc-facebook-event">
+  <template>
+    <style include="shared-styles">
+      h1 {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: inherit;
+      }
+      paper-icon-item {
+        --paper-item-icon-width: 40px;
+      }
+      iron-icon {
+        --iron-icon-width: 24px;
+        --iron-icon-height: 24px;
+        --iron-icon: {
+          color: black;
+          opacity: var(--dark-secondary-opacity);
+        };
+      }
+      paper-icon-item a {
+        color: inherit;
+        text-decoration: none;
+      }
+    </style>
+
+    <paper-card
+        id="card"
+        class="wvtc-card"
+        image="[[event.cover.source]]">
+      <div class="card-content">
+        <h1>[[event.name]]</h1>
+        <paper-icon-item>
+          <iron-icon icon="schedule" item-icon></iron-icon>
+          <paper-item-body>
+            <div>[[_formatDate(event.start_time)]]</div>
+            <div secondary>[[_formatTime(event.start_time, event.end_time)]]</div>
+          </paper-item-body>
+        </paper-icon-item>
+          <paper-icon-item>
+            <iron-icon icon="maps:place" item-icon></iron-icon>
+            <a href$="[[_formatMapsUrl(event.place)]]"
+               rel="external"
+               target="_blank">
+              <paper-item-body two-line>
+                <div>[[event.place.name]]</div>
+                <div secondary>[[_formatLocation(event.place.location)]]</div>
+              </paper-item-body>
+            </a>
+          </paper-icon-item>
+      </div>
+      <div class="card-actions">
+        <a href="https://www.facebook.com/events/{{event.id}}/"
+           rel="external"
+           target="_blank"
+           hidden$="{{!!event.id}}">
+          <paper-button>Details</paper-button>
+        </a>
+      </div>
+    </paper-card>
+  </template>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
+  <script>
+    Polymer({
+      is: 'wvtc-facebook-event',
+      properties: {
+        event: Object
+      },
+      _formatDate: function(date) {
+        return moment(date).format('ddd, MMMM D');
+      },
+      _formatTime: function(start_date, end_date) {
+        var time = moment(start_date).format('h:mm A');
+        if (!!end_date) {
+          time += moment(end_date).format(' — h:mm A');
+        }
+        return time;
+      },
+      _formatLocation: function(location) {
+        var city = location.city + ', ' + location.state + ' ' + location.zip;
+        if (!location.street) return city;
+
+        return location.street + ', ' + city;
+      },
+      _formatMapsUrl: function(place) {
+        var location = place.location;
+        var query = encodeURIComponent(
+            place.name + ', ' + this._formatLocation(location));
+        return 'http://maps.google.com/?ll=' + location.latitude + ',' +
+            location.longitude + '&q=' + query;
+      }
+    });
+  </script>
+</dom-module>

--- a/src/wvtc-membership.html
+++ b/src/wvtc-membership.html
@@ -146,7 +146,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
       hasPaidDues: function(membership) {
-        console.log(!!membership.paidOn);
         return !!membership && !!membership.paidOn;
       },
       _formatDate: function(date) {

--- a/src/wvtc-social-media.html
+++ b/src/wvtc-social-media.html
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <a href="[[page]]" rel="external" target="_blank">
         <paper-icon-button icon="wvtc-icons:external-link"></paper-icon-button>
       </a>
-    </paper-item>
+    </paper-icon-item>
   </template>
 
   <script>

--- a/src/wvtc-upcoming-events.html
+++ b/src/wvtc-upcoming-events.html
@@ -12,27 +12,107 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="shared-styles.html">
-<link rel="import" href="wvtc-title-card.html">
+<link rel="import" href="wvtc-facebook-event.html">
 
 <dom-module id="wvtc-upcoming-events">
   <template>
     <style include="shared-styles"></style>
 
     <div class="wvtc-panel">
-      <wvtc-title-card
-          id="title-card"
-          heading="Upcoming Events"
-          image="../images/photos/upcoming-events.jpg"
-          icon="event">
-        <p>Modus commodo minimum eum te, vero utinam assueverit per eu.</p>
-        <p>Ea duis bonorum nec, falli paulo aliquid ei eum.Has at minim mucius aliquam, est id tempor laoreet.Pro saepe pertinax ei, ad pri animal labores suscipiantur.</p>
-      </wvtc-title-card>
+      <h2 class="wvtc-subheader">Upcoming events</h2>
+      <template is="dom-repeat" items="{{events}}" as="event">
+        <wvtc-facebook-event event="[[event]]"></wvtc-facebook-event>
+      </template>
     </div>
   </template>
 
   <script>
     Polymer({
-      is: 'wvtc-upcoming-events'
+      is: 'wvtc-upcoming-events',
+      properties: {
+        events: {
+          type: Array,
+          value: function() {
+            return [
+              {
+                "id": "1342777902445861",
+                "name": "Stow Lake Stampede 5K (and Kid's Mile)",
+                "place": {
+                  "name": "Golden Gate Park - Peacock Meadow",
+                  "location": {
+                    "city": "San Francisco",
+                    "country": "United States",
+                    "latitude": 37.771493936924,
+                    "located_in": "480553381967378",
+                    "longitude": -122.45779641518,
+                    "state": "CA",
+                    "zip": "94117"
+                  },
+                  "id": "145646782125468"
+                },
+                "cover": {
+                  "offset_x": 0,
+                  "offset_y": 50,
+                  "source": "https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/17264675_10154444356825950_1421215239976919764_n.jpg?oh=68599f1a84f9e46f0ad5c8da3dc5ad00&oe=59552A48",
+                  "id": "10154444356825950"
+                },
+                "start_time": "2017-04-23T07:30:00-0700",
+                "end_time": "2017-04-23T10:30:00-0700"
+              },
+              {
+                "id": "1006919159410183",
+                "name": "5th Annual Paavo Nurmi Two Mile",
+                "place": {
+                  "name": "Kezar Stadium",
+                  "location": {
+                    "city": "San Francisco",
+                    "country": "United States",
+                    "latitude": 37.766944444444,
+                    "longitude": -122.45611111111,
+                    "state": "CA",
+                    "street": "670 Kezar Drive",
+                    "zip": "94117"
+                  },
+                  "id": "103211553067740"
+                },
+                "cover": {
+                  "offset_x": 0,
+                  "offset_y": 0,
+                  "source": "https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/17796030_1848921545357348_1448527110608353309_n.jpg?oh=50ae3bad1d5c85ca7d1cf3b2e07eca4a&oe=598EBA0B",
+                  "id": "1848921545357348"
+                },
+                "start_time": "2017-05-02T18:30:00-0700",
+                "end_time": "2017-05-02T19:00:00-0700"
+              },
+              {
+                "id": "107942319741264",
+                "name": "Marin Memorial Day 10K, Don Ritchie 5K, and Youth Track Races",
+                "place": {
+                  "name": "College of Marin",
+                  "location": {
+                    "city": "Kentfield",
+                    "country": "United States",
+                    "latitude": 37.954932628157,
+                    "longitude": -122.5496789239,
+                    "state": "CA",
+                    "street": "835 College Ave",
+                    "zip": "94904"
+                  },
+                  "id": "110940541990"
+                },
+                "cover": {
+                  "offset_x": 0,
+                  "offset_y": 0,
+                  "source": "https://scontent.xx.fbcdn.net/v/t31.0-8/s720x720/17239826_1544971835535649_6683853682457319663_o.jpg?oh=f0fd46d6bfbbe27fe5cdf87ccb0dc498&oe=595E3738",
+                  "id": "1544971835535649"
+                },
+                "start_time": "2017-05-29T08:00:00-0700",
+                "end_time": "2017-05-29T11:00:00-0700"
+              }
+            ];
+          }
+        }
+      }
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Adds a component for upcoming Facebook events, showing the event's name, cover picture, time, and location.  Also links to the Facebook event page.  Hardcodes event data from the three most recent events to display on the Upcoming events page.

This change contributes to issue #9.