### PR TITLE
Hardcode Bay to Breakers in upcoming events page.

### DIFF
--- a/src/wvtc-event-place.html
+++ b/src/wvtc-event-place.html
@@ -55,11 +55,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         place: Object
       },
       _formUrl: function(place) {
-        var location = place.location;
-        var query = encodeURIComponent(
-            place.name + ', ' + this._formatLocation(place));
-        return 'http://maps.google.com/?ll=' + location.latitude + ',' +
-            location.longitude + '&q=' + query;
+        var query = encodeURIComponent(place.name);
+        var formattedLocation = this._formatLocation(place);
+        if (!!formattedLocation) {
+          query += encodeURIComponent(', ' + formattedLocation);
+        }
+
+        var geo = encodeURIComponent(
+            place.location.latitude + ',' + place.location.longitude);
+
+        return 'http://maps.google.com/?ll=' + geo + '&q=' + query;
       },
       _formatLocation: function(place) {
         var location = place.location;

--- a/src/wvtc-event-place.html
+++ b/src/wvtc-event-place.html
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <a href$="[[_formUrl(place)]]" rel="external" target="_blank">
         <paper-item-body two-line>
           <div>[[place.name]]</div>
-          <div secondary>[[_formatLocation(place.location)]]</div>
+          <div secondary>[[_formatLocation(place)]]</div>
         </paper-item-body>
       </a>
     </paper-icon-item>
@@ -57,12 +57,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _formUrl: function(place) {
         var location = place.location;
         var query = encodeURIComponent(
-            place.name + ', ' + this._formatLocation(location));
+            place.name + ', ' + this._formatLocation(place));
         return 'http://maps.google.com/?ll=' + location.latitude + ',' +
             location.longitude + '&q=' + query;
       },
-      _formatLocation: function(location) {
-        var city = location.city + ', ' + location.state + ' ' + location.zip;
+      _formatLocation: function(place) {
+        var location = place.location;
+        var city = location.city + ', ' + location.state;
+        if (!!location.zip) {
+          city += ' ' + location.zip;
+        }
+
+        if (place.name == city) return '';
+
         if (!location.street) return city;
 
         return location.street + ', ' + city;

--- a/src/wvtc-upcoming-events.html
+++ b/src/wvtc-upcoming-events.html
@@ -85,6 +85,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 "end_time": "2017-05-02T19:00:00-0700"
               },
               {
+                "id": "203561610078937",
+                "name": "Alaska Airlines Bay to Breakers",
+                "place": {
+                  "name": "San Francisco, CA",
+                  "location": {
+                    "city": "San Francisco",
+                    "country": "United States",
+                    "latitude": 37.775,
+                    "longitude": -122.418,
+                    "state": "CA"
+                  },
+                  "id": "114952118516947"
+                },
+                "cover": {
+                  "offset_x": 0,
+                  "offset_y": 0,
+                  "source": "https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/17342969_10158417498735451_6195616967487250323_n.jpg?oh=905d88e655da5c98fa8ed9fa6ff3c212&oe=5953E087",
+                  "id": "10158417498735451"
+                },
+                "start_time": "2017-05-21T00:00:00-0700",
+                "end_time": "2017-05-21T23:59:00-0700"
+              },
+              {
                 "id": "107942319741264",
                 "name": "Marin Memorial Day 10K, Don Ritchie 5K, and Youth Track Races",
                 "place": {


### PR DESCRIPTION
Hardcodes the Bay to Breakers event into the upcoming events page.  Also adds handling for events (1) that don't have a zip code and (2) whose place name is the same as the city and state.

This change contributes to #9.