### PR TITLE
Fix broken web app.

### DIFF
--- a/src/wvtc-communication.html
+++ b/src/wvtc-communication.html
@@ -16,7 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="wvtc-google-group.html">
 <link rel="import" href="wvtc-icons.html">
 <link rel="import" href="wvtc-social-media.html">
-<link rel="import" href="wvtc-title-card.html">
 
 <dom-module id="wvtc-communication">
   <template>


### PR DESCRIPTION
Removes a reference to a deleted file, which caused 'polymer build' to silently fail by not printing 'Build complete!' but otherwise not indicating any errors.  Deploying to Firebase resulted in a web app that didn't load or used cached content.  The console showed logging like:

`The script has an unsupported MIME type ('text/html')`