### PR TITLE
Update database rules to restrict access.

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,6 +1,28 @@
 {
   "rules": {
-    ".read": "auth != null",
-    ".write": "auth != null"
+    "users": {
+      "$uid": {
+        ".read": "$uid === auth.uid",
+        ".write": "$uid === auth.uid"
+      }
+    },
+    "members": {
+      "$year": {
+        "$uid": {
+          ".read": "$uid === auth.uid",
+          ".write": false
+        }
+      }
+    },
+    "races": {
+      ".read": "auth != null",
+      ".write": false
+    },
+    "benefits": {
+      ".read": "root.child('members/all/' + auth.uid + '/year')
+                    .val()
+                    .matches(/^2017|lifetime$/)",
+      ".write": false
+    }
   }
 }


### PR DESCRIPTION
Restricts access to the Firebase database such that:

- Users can read and write only their own user record
- Users can read but not write their own member record
- Any authenticated user can read race records
- Only 2017 or lifetime members can read benefits

This change contributes to #29.