### PR TITLE
Fix database rules by removing new lines.

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -19,9 +19,7 @@
       ".write": false
     },
     "benefits": {
-      ".read": "root.child('members/all/' + auth.uid + '/year')
-                    .val()
-                    .matches(/^2017|lifetime$/)",
+      ".read": "root.child('members/all/' + auth.uid + '/year').val().matches(/^2017|lifetime$/)",
       ".write": false
     }
   }


### PR DESCRIPTION
Despite what the Firebase documentation shows and what the simulator accepts, newline characters are not allowed within strings.  This change contributes to #29.