### PR TITLE
Update Stripe charge with email so receipt is sent.

### DIFF
--- a/src/wvtc-stripe-checkout.html
+++ b/src/wvtc-stripe-checkout.html
@@ -78,6 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             };
             request.send(JSON.stringify({
               uid: self.user.uid,
+              email: token.email,
               sku: sku,
               tokenId: token.id
             }));


### PR DESCRIPTION
Updates the Stripe charge with an email address so that a receipt is sent.  This is a workaround for a bug in the Stripe API where a receipt is not sent for orders paid using a token even if both the order and the token have an associated email.