### PR TITLE
Remove Stow Lake Stampede from upcoming events.

### DIFF
--- a/src/wvtc-upcoming-events.html
+++ b/src/wvtc-upcoming-events.html
@@ -35,31 +35,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           value: function() {
             return [
               {
-                "id": "1342777902445861",
-                "name": "Stow Lake Stampede 5K (and Kid's Mile)",
-                "place": {
-                  "name": "Golden Gate Park - Peacock Meadow",
-                  "location": {
-                    "city": "San Francisco",
-                    "country": "United States",
-                    "latitude": 37.771493936924,
-                    "located_in": "480553381967378",
-                    "longitude": -122.45779641518,
-                    "state": "CA",
-                    "zip": "94117"
-                  },
-                  "id": "145646782125468"
-                },
-                "cover": {
-                  "offset_x": 0,
-                  "offset_y": 50,
-                  "source": "https://scontent.xx.fbcdn.net/v/t1.0-9/s720x720/17264675_10154444356825950_1421215239976919764_n.jpg?oh=68599f1a84f9e46f0ad5c8da3dc5ad00&oe=59552A48",
-                  "id": "10154444356825950"
-                },
-                "start_time": "2017-04-23T07:30:00-0700",
-                "end_time": "2017-04-23T10:30:00-0700"
-              },
-              {
                 "id": "1006919159410183",
                 "name": "5th Annual Paavo Nurmi Two Mile",
                 "place": {


### PR DESCRIPTION
Removes data for the Stow Lake Stampede 5K from the Upcoming Events page since the event has been passed.  In the future, upcoming events should be pulled from Facebook.