### PR TITLE
Use build/default for public hosting directory.

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,7 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "build/bundled",
+    "public": "build/default",
     "rewrites": [
       {
         "source": "!/__/**",


### PR DESCRIPTION
The latest version of the polymer command-line tool uses build/default for building.