### PR TITLE
Sort race schedule by event start time.

### DIFF
--- a/src/wvtc-racing-schedule.html
+++ b/src/wvtc-racing-schedule.html
@@ -25,7 +25,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <firebase-query
         app-name="wvtc"
         path="/races/[[year]]/[[type]]"
-        data="{{firebaseRaces}}">
+        data="{{firebaseRaces}}"
+        order-by-child="event/start_time">
     </firebase-query>
     <app-indexeddb-mirror
         key="races/[[year]]/[[type]]"


### PR DESCRIPTION
Sorts race schedules by event start time.  This is needed because races are now keyed by a human readable string rather than an increasing id.