### PR TITLE
Pass year along from admin page.

### DIFF
--- a/src/wvtc-admin.html
+++ b/src/wvtc-admin.html
@@ -33,7 +33,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           class="wvtc-card wvtc-item-list"
           role="listbox">
         <div class="card-content">
-          <wvtc-reimbursement-races races="{{_races}}">
+          <wvtc-reimbursement-races
+              races="{{_races}}"
+              year="[[year]]">
           </wvtc-reimbursement-races>
           <template is="dom-repeat" items="{{requesters}}" as="uid">
             <wvtc-reimbursement-record


### PR DESCRIPTION
Fixes the admin page by passing the year along to the wvtc-reimbursement-races component.