### PR TITLE
Fix event attendance for 2018 and onward.

### DIFF
--- a/src/wvtc-event-attendance.html
+++ b/src/wvtc-event-attendance.html
@@ -76,17 +76,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <firebase-document
         app-name="wvtc"
-        path="/attendance/2017/[[eid]]"
+        path="/attendance/[[year]]/[[eid]]"
         data="{{_attendance}}">
     </firebase-document>
     <firebase-document
         app-name="wvtc"
-        path="/attendance/2017/[[eid]]/[[uid]]/response"
+        path="/attendance/[[year]]/[[eid]]/[[uid]]/response"
         data="{{_response}}">
     </firebase-document>
     <firebase-document
         app-name="wvtc"
-        path="/attendance/2017/[[eid]]/[[uid]]/carpool"
+        path="/attendance/[[year]]/[[eid]]/[[uid]]/carpool"
         data="{{_carpool}}">
     </firebase-document>
 
@@ -173,6 +173,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         name: String,
         uid: String,
         eid: String,
+        year: Number,
         yesRsvp: {
           type: Array,
           computed: '_computeYesRsvp(_attendance.*)'

--- a/src/wvtc-race.html
+++ b/src/wvtc-race.html
@@ -62,7 +62,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             hidden$="{{!isActiveMember}}"
             name="[[race.name]]"
             uid="[[uid]]"
-            eid="[[eid]]">
+            eid="[[eid]]"
+            year="[[year]]">
         </wvtc-event-attendance>
       </div>
     </iron-collapse>
@@ -77,6 +78,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         eid: String,
         race: Object,
         membership: Object,
+        year: Number,
         opened: Boolean,
         _toggleIcon: {
           type: String,

--- a/src/wvtc-racing-schedule.html
+++ b/src/wvtc-racing-schedule.html
@@ -48,7 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 uid="{{user.uid}}"
                 eid="{{item.$key}}"
                 race="{{item}}"
-                membership="[[membership]]">
+                membership="[[membership]]"
+                year="[[year]]">
             </wvtc-race>
           </template>
         </div>


### PR DESCRIPTION
Parameterizes the event attendance component with a year instead of hardcoding 2017.  Otherwise, event ids may clash in future years.