### PR TITLE
Extend reimbursement deadline to January 15

### DIFF
--- a/src/wvtc-reimbursement-card.html
+++ b/src/wvtc-reimbursement-card.html
@@ -155,8 +155,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         year: {
           type: Number,
           value: function() {
-            var now = new Date();
-            return now.getFullYear();
+            // TODO(jkczyz) Revert this once extended deadline has passed.
+            //var now = new Date();
+            //return now.getFullYear();
+            return 2018;
           }
         },
         eligibleRaces: {


### PR DESCRIPTION
Extends the reimbursement deadline until January 15 given Clarksburg half marathon was postponed until January 13. This temporarily hardcodes the reimbursement year to 2018 so that the reimbursement form is populated with races.