### PR TITLE
Make the status of race reimbursement requests editable.

### DIFF
--- a/src/wvtc-admin.html
+++ b/src/wvtc-admin.html
@@ -67,9 +67,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <template is="dom-repeat" items="{{requesters}}" as="uid">
             <wvtc-reimbursement-record
                 class="wvtc-item"
+                year="{{year}}"
                 uid="{{uid}}"
-                races={{_races}}
-                reimbursements="{{_reimbursementRequests(_reimbursements.*, uid)}}">
+                races="[[_races]]">
             </wvtc-reimbursement-record>
           </template>
         </div>

--- a/src/wvtc-reimbursement-card.html
+++ b/src/wvtc-reimbursement-card.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="shared-styles.html">
 <link rel="import" href="wvtc-reimbursement-pref.html">
 <link rel="import" href="wvtc-reimbursement-races.html">
+<link rel="import" href="wvtc-reimbursement-requests.html">
 <link rel="import" href="wvtc-reimbursement-table.html">
 <link rel="import" href="wvtc-year-selector.html">
 
@@ -81,12 +82,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
 
     <firebase-document
-        id="reimbursements"
-        app-name="wvtc"
-        path="/reimbursements/[[year]]/[[user.uid]]"
-        data="{{_reimbursements}}">
-    </firebase-document>
-    <firebase-document
         id="first-deadline"
         app-name="wvtc"
         path="/benefits/reimbursements/deadlines/[[year]]/first"
@@ -135,10 +130,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             races="{{_races}}"
             year="[[year]]">
         </wvtc-reimbursement-races>
+        <wvtc-reimbursement-requests
+            id="requests"
+            year="[[year]]"
+            uid="[[user.uid]]"
+            races="[[_races]]"
+            requests="{{_requests}}">
+        </wvtc-reimbursement-requests>
         <wvtc-reimbursement-table
-            hidden$="{{!_hasRequestedReimbursements(_reimbursements.*)}}"
-            races={{_races}}
-            reimbursements="{{_reimbursements}}">
+            hidden$="{{!_hasRequestedReimbursements(_requests.*)}}"
+            requests="{{_requests}}">
         </wvtc-reimbursement-table>
       </div>
       <div class="card-actions">
@@ -177,7 +178,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
         eligibleRaces: {
           type: Array,
-          computed: '_computeEligibleRaces(_races, _reimbursements.*, window)'
+          computed: '_computeEligibleRaces(_races, _requests.*, window)'
         },
         _toggleIcon: {
           type: String,
@@ -205,7 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           end: deadline
         };
       },
-      _computeEligibleRaces: function(allRaces, reimbursements, window) {
+      _computeEligibleRaces: function(allRaces, requests, window) {
         var now = new Date();
         if (now.toJSON() > window.end.toJSON()) {
           return [];
@@ -228,16 +229,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                  race.date <= window.end.toJSON();
         };
         var hasNotBeenRequested = function(race) {
-          return !reimbursements.base.hasOwnProperty(race.id);
+          var hasSameRaceId = function(request) {
+            return request.id == race.id;
+          }
+          return !requests.base.some(hasSameRaceId);
         };
 
-        return allRaces.sort(compareByDate)
-                       .filter(isPast)
-                       .filter(isInWindow)
-                       .filter(hasNotBeenRequested);
+        return Object.values(allRaces)
+                     .sort(compareByDate)
+                     .filter(isPast)
+                     .filter(isInWindow)
+                     .filter(hasNotBeenRequested);
       },
-      _hasRequestedReimbursements: function(reimbursements) {
-        return !this.$.reimbursements.valueIsEmpty(reimbursements.base);
+      _hasRequestedReimbursements: function(requests) {
+        return requests.base.length > 0;
       },
       _formatDeadline: function(deadline) {
         var now = new Date();
@@ -258,11 +263,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
       _requestReimbursement: function() {
         var race = this.selectedRace;
-        var now = new Date();
-        this.set('_reimbursements.' + race.id, {
-          requestedOn: now.toJSON(),
-          status: 'Pending'
-        });
+        this.$.requests.requestReimbursement(race);
         this.selectedRace = null;
       },
       _updateSelectedRace: function(year) {

--- a/src/wvtc-reimbursement-races.html
+++ b/src/wvtc-reimbursement-races.html
@@ -16,11 +16,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="wvtc-reimbursement-races">
   <template>
     <firebase-document
+        id="road-races"
         app-name="wvtc"
         path="/races/[[year]]/road"
         data="{{_roadRaces}}">
     </firebase-document>
     <firebase-document
+        id="xc-races"
         app-name="wvtc"
         path="/races/[[year]]/xc"
         data="{{_xcRaces}}">
@@ -32,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'wvtc-reimbursement-races',
       properties: {
         races: {
-          type: Array,
+          type: Object,
           computed: '_computeRaces(_xcRaces, _roadRaces)',
           notify: true,
           readOnly: true
@@ -42,6 +44,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         _roadRaces: Object
       },
       _computeRaces: function(xcRaces, roadRaces) {
+        if (this.$['road-races'].valueIsEmpty(roadRaces) ||
+            this.$['xc-races'].valueIsEmpty(xcRaces)) {
+          return undefined;
+        }
+
         var toSimplifiedRace = function(races) {
           return function(id) {
             var race = races[id];
@@ -49,13 +56,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               id: id,
               name: race.name,
               date: race.date,
-              amount: race.reimbursementAmount
+              amount: race.reimbursementAmount || 0
             };
           };
         };
+        var mapIdToRace = function(map, race) {
+          map[race.id] = race;
+          return map;
+        };
+
         var xc = Object.keys(xcRaces).map(toSimplifiedRace(xcRaces));
         var road = Object.keys(roadRaces).map(toSimplifiedRace(roadRaces));
-        return xc.concat(road);
+        return xc.concat(road).reduce(mapIdToRace, {});
       }
     });
   </script>

--- a/src/wvtc-reimbursement-record.html
+++ b/src/wvtc-reimbursement-record.html
@@ -40,17 +40,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         path="/users/{{uid}}"
         data="{{user}}">
     </firebase-document>
-    <wvtc-reimbursement-requests
-        reimbursements="{{reimbursements}}"
-        races="{{races}}"
-        requests="{{requests}}">
-    </wvtc-reimbursement-requests>
     <paper-item>
       <paper-item-body two-line>
         <div>[[user.displayName]]</div>
         <div secondary>[[_reimbursementMethod(user)]]</div>
       </paper-item-body>
-      <div class="amount">[[_amountOwed(requests)]]</div>
+      <div class="amount">[[_amountOwed(_requests)]]</div>
       <paper-icon-button
           class="toggle"
           icon="[[_toggleIcon]]"
@@ -58,9 +53,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </paper-icon-button>
     </paper-item>
     <iron-collapse opened={{opened}}>
+      <wvtc-reimbursement-requests
+          year="[[year]]"
+          uid="[[uid]]"
+          races="[[races]]"
+          requests="{{_requests}}">
+      </wvtc-reimbursement-requests>
       <wvtc-reimbursement-table
-          races="{{races}}"
-          reimbursements="{{reimbursements}}">
+          editable="[[editable]]"
+          requests="[[_requests]]">
       </wvtc-reimbursement-table>
     </iron-collapse>
   </template>
@@ -69,10 +70,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer({
       is: 'wvtc-reimbursement-record',
       properties: {
+        year: Number,
         uid: String,
         user: Object,
-        reimbursements: Object,
-        races: Array,
+        races: Object,
+        _requests: Array,
+        editable: Boolean,
         opened: Boolean,
         _toggleIcon: {
           type: String,
@@ -108,8 +111,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return '$' + (amountOwed / 100);
       },
       toggleOpened: function() {
+        // Only set editable upon opening the record to avoid slowness seen when
+        // first loading the page. This can happen when the page contains
+        // multiple records each with many paper-dropdown-menu elements.
+        this.editable = true;
         this.opened = !this.opened;
-        this.selected = this.selected || 0;
       },
       _computeToggleIcon: function(opened) {
         return opened ? 'icons:expand-less' : 'icons:expand-more';

--- a/src/wvtc-reimbursement-requests.html
+++ b/src/wvtc-reimbursement-requests.html
@@ -11,37 +11,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/polymerfire/firebase-query.html">
 
 <dom-module id="wvtc-reimbursement-requests">
+  <template>
+      <firebase-query
+          id="reimbursements"
+          app-name="wvtc"
+          path="/reimbursements/[[year]]/[[uid]]"
+          data="{{_reimbursements}}">
+      </firebase-query>
+  </template>
   <script>
     Polymer({
       is: 'wvtc-reimbursement-requests',
       properties: {
-        races: Array,
-        reimbursements: Object,
+        year: Number,
+        uid: String,
+        races: Object,
+        _reimbursements: Array,
         requests: {
           type: Array,
-          computed: '_computeRequests(races, reimbursements.*)',
+          computed: '_computeRequests(races, _reimbursements.*)',
           notify: true
         }
       },
       _computeRequests: function(races, reimbursements) {
-        var hasRequestedReimbursement = function(race) {
-          return reimbursements.base.hasOwnProperty(race.id);
-        };
-        var toReimbursementRequest = function(race) {
-          var request = reimbursements.base[race.id];
+        var self = this;
+        var toCompleteRequest = function(reimbursement) {
+          var id = reimbursement.$key;
+          var race = races[id];
           return {
+            id: id,
             race: race.name,
-            requestedOn: request.requestedOn,
+            requestedOn: reimbursement.requestedOn,
             amount: race.amount,
-            status: request.status
+            status: reimbursement.status,
+            updateStatus: function(status) {
+              self.$.reimbursements.ref.child(id).update({
+                status: status
+              });
+            }
           };
         };
 
-        return races.filter(hasRequestedReimbursement)
-                    .map(toReimbursementRequest);
+        return reimbursements.base.map(toCompleteRequest);
       },
+      requestReimbursement: function(race) {
+        var now = new Date();
+        this.$.reimbursements.ref.child(race.id).set({
+          requestedOn: now.toJSON(),
+          status: 'Pending'
+        });
+      }
     });
   </script>
 </dom-module>

--- a/src/wvtc-reimbursement-status.html
+++ b/src/wvtc-reimbursement-status.html
@@ -1,0 +1,77 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors.
+Copyright (c) 2019 West Valley Track Club, Inc.
+All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../bower_components/paper-dropdown-menu/paper-dropdown-menu-light.html">
+<link rel="import" href="../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="shared-styles.html">
+
+<dom-module id="wvtc-reimbursement-status">
+  <template>
+    <style include="shared-styles">
+      paper-dropdown-menu-light {
+        --paper-dropdown-menu-input: {
+          font-size: inherit;
+        };
+      }
+      paper-item {
+        --paper-item: {
+          font-size: inherit;
+        };
+      }
+    </style>
+    <paper-dropdown-menu-light no-float-label>
+      <paper-listbox
+          class="dropdown-content"
+          selected="{{status}}"
+          attr-for-selected="name">
+        <template is="dom-repeat" items="{{choices}}">
+          <paper-item name="[[item]]">{{item}}</paper-item>
+        </template>
+      </paper-listbox>
+    </paper-dropdown-menu-light>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'wvtc-reimbursement-status',
+      properties: {
+        request: Object,
+        status: {
+          type: String,
+          observer: '_statusChanged'
+        },
+        choices: {
+          type: Array,
+          value: function() {
+            return [
+              "Pending",
+              "Verified",
+              "Paid",
+              "Denied",
+              "Denied (WVTC membership)",
+              "Denied (USATF membership)",
+              "Denied (Did not race)",
+              "Denied (Members free)",
+            ];
+          }
+        }
+      },
+      _statusChanged: function(newValue, oldValue) {
+        if (!!oldValue && oldValue != newValue) {
+          this.request.updateStatus(newValue);
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/src/wvtc-reimbursement-summary.html
+++ b/src/wvtc-reimbursement-summary.html
@@ -21,13 +21,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <paper-item>
       <paper-item-body two-line>
         <div>
-          Paid [[_sumRequests(_paidRequests, _reimbursementAmounts)]]
+          Paid [[_sumRequests(_paidRequests, races)]]
           to [[_countUniqueRequesters(_paidRequests)]] members
         </div>
         <div secondary>
-            [[_sumRequests(_pendingRequests, _reimbursementAmounts)]] pending,
-            [[_sumRequests(_verifiedRequests, _reimbursementAmounts)]] verified,
-            [[_sumRequests(_deniedRequests, _reimbursementAmounts)]] denied
+            [[_sumRequests(_pendingRequests, races)]] pending,
+            [[_sumRequests(_verifiedRequests, races)]] verified,
+            [[_sumRequests(_deniedRequests, races)]] denied
         </div>
       </paper-item-body>
     </paper-item>
@@ -38,14 +38,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'wvtc-reimbursement-summary',
       properties: {
         reimbursements: Object,
-        races: Array,
+        races: Object,
         _reimbursementRequests: {
           type: Array,
           computed: '_computeReimbursementRequests(reimbursements.*)'
-        },
-        _reimbursementAmounts: {
-          type: Object,
-          computed: '_computeReimbursementAmounts(races)'
         },
         _pendingRequests: {
           type: Array,
@@ -80,14 +76,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         return reimbursementRequests;
       },
-      _computeReimbursementAmounts(races) {
-        var mapRaceIdToReimbursementAmount = function(map, race) {
-          map[race.id] = race.amount || 0;
-          return map;
-        };
-
-        return races.reduce(mapRaceIdToReimbursementAmount, {});
-      },
       _computePendingRequests: function(requests) {
         var isPending = function(request) {
           return request.status == 'Pending';
@@ -112,9 +100,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
         return requests.filter(isDenied);
       },
-      _sumRequests: function(requests, amounts) {
+      _sumRequests: function(requests, races) {
         var toAmount = function(request) {
-          return amounts[request.eid];
+          return races[request.eid].amount;
         };
         var sumAmounts = function(sum, value) {
           return sum + value;

--- a/src/wvtc-reimbursement-table.html
+++ b/src/wvtc-reimbursement-table.html
@@ -12,39 +12,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../bower_components/paper-datatable/paper-datatable.html">
 <link rel="import" href="../bower_components/paper-datatable/paper-datatable-column.html">
+<link rel="import" href="../bower_components/paper-radio-button/paper-radio-button.html">
+<link rel="import" href="../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="shared-styles.html">
-<link rel="import" href="wvtc-reimbursement-requests.html">
+<link rel="import" href="wvtc-reimbursement-status.html">
 
 <dom-module id="wvtc-reimbursement-table">
   <template>
-    <wvtc-reimbursement-requests
-        reimbursements="{{reimbursements}}"
-        races="{{races}}"
-        requests="{{requests}}">
-    </wvtc-reimbursement-requests>
-    <paper-datatable
-        data="{{requests}}"
-        resize-behavior="overflow">
-      <paper-datatable-column header="Race" property="race">
-      </paper-datatable-column>
-      <paper-datatable-column
-          header="Amount"
-          property="amount"
-          type="Number">
-        <template>{{_formatAmount(value)}}</template>
-      </paper-datatable-column>
-      <paper-datatable-column header="Status" property="status">
-      </paper-datatable-column>
-    </paper-datatable>
+    <style include="shared-styles"></style>
+
+    <template is="dom-if" if="{{editable}}">
+      <paper-datatable data="{{requests}}" resize-behavior="overflow">
+        <paper-datatable-column header="Race" property="race">
+        </paper-datatable-column>
+        <paper-datatable-column header="Amount" property="amount" type="Number">
+          <template>{{_formatAmount(value)}}</template>
+        </paper-datatable-column>
+        <paper-datatable-column header="Status" property="status">
+          <template>
+            <wvtc-reimbursement-status request="{{item}}" status="{{value}}">
+            </wvtc-reimbursement-status>
+          </template>
+        </paper-datatable-column>
+      </paper-datatable>
+    </template>
+
+    <template is="dom-if" if="{{!editable}}">
+      <paper-datatable data="{{requests}}" resize-behavior="overflow">
+        <paper-datatable-column header="Race" property="race">
+        </paper-datatable-column>
+        <paper-datatable-column header="Amount" property="amount" type="Number">
+          <template>{{_formatAmount(value)}}</template>
+        </paper-datatable-column>
+        <paper-datatable-column header="Status" property="status">
+        </paper-datatable-column>
+      </paper-datatable>
+    </template>
   </template>
 
   <script>
     Polymer({
       is: 'wvtc-reimbursement-table',
       properties: {
-        reimbursements: Object,
-        races: Array
+        requests: Array,
+        editable: {
+          type: Boolean,
+          value: false
+        }
       },
       _formatAmount: function(amount) {
         if (!amount) {


### PR DESCRIPTION
Makes race reimbursement requests editable by using `paper-dropdown-menu` for the request's status. The status is only editable from the Admin page and only if the user has permission to modify the request in Firebase. This change involves extensive refactoring of the reimbursement elements such that `wvtc-reimbursement-requests` has greater responsibility for constructing requests to feed to `wvtc-reimbursement-table` and for managing the requests in Firebase.