### PR TITLE
add MUT races for schedule and reimbursement pages

### DIFF
--- a/src/wvtc-racing.html
+++ b/src/wvtc-racing.html
@@ -37,7 +37,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             type="road">
         </wvtc-racing-schedule>
       </div>
-      
       <div>
         <h2 class="wvtc-subheader">[[year]] PA USATF Cross Country</h2>
         <wvtc-racing-schedule
@@ -45,6 +44,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             membership=[[membership]]
             year="[[year]]"
             type="xc">
+        </wvtc-racing-schedule>
+      </div>
+      <div>
+        <h2 class="wvtc-subheader">[[year]] PA USATF Mountain-Ultra-Trail</h2>
+        <wvtc-racing-schedule
+            user="[[user]]"
+            membership=[[membership]]
+            year="[[year]]"
+            type="mut">
         </wvtc-racing-schedule>
       </div>
     </div>

--- a/src/wvtc-reimbursement-races.html
+++ b/src/wvtc-reimbursement-races.html
@@ -27,6 +27,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         path="/races/[[year]]/xc"
         data="{{_xcRaces}}">
     </firebase-document>
+    <firebase-document
+        id="mut-races"
+        app-name="wvtc"
+        path="/races/[[year]]/mut"
+        data="{{_mutRaces}}">
+    </firebase-document>
   </template>
 
   <script>
@@ -35,15 +41,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       properties: {
         races: {
           type: Object,
-          computed: '_computeRaces(_xcRaces, _roadRaces)',
+          computed: '_computeRaces(_xcRaces, _roadRaces, _mutRaces)',
           notify: true,
           readOnly: true
         },
         year: Number,
         _xcRaces: Object,
-        _roadRaces: Object
+        _roadRaces: Object,
+        _mutRaces: Object,
       },
-      _computeRaces: function(xcRaces, roadRaces) {
+      _computeRaces: function(xcRaces, roadRaces, mutRaces) {
+        // NOTE: not including mutRaces so that the drop down will continue
+        // to work for years prior to 2020 when we didn't include MUT.
         if (this.$['road-races'].valueIsEmpty(roadRaces) ||
             this.$['xc-races'].valueIsEmpty(xcRaces)) {
           return undefined;
@@ -67,7 +76,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         var xc = Object.keys(xcRaces).map(toSimplifiedRace(xcRaces));
         var road = Object.keys(roadRaces).map(toSimplifiedRace(roadRaces));
-        return xc.concat(road).reduce(mapIdToRace, {});
+        var mut = Object.keys(mutRaces).map(toSimplifiedRace(mutRaces));
+        return xc.concat(road).concat(mut).reduce(mapIdToRace, {});
       }
     });
   </script>


### PR DESCRIPTION
This PR adds support to the Reimbursement and Schedule pages to display MUT (mountain/ultra/trail) races.

I've added the 3 MUT races that actually happened in 2020 to the Firebase database:
<img width="457" alt="Screen Shot 2020-07-01 at 6 36 16 PM" src="https://user-images.githubusercontent.com/2801090/86306685-c4098400-bbc9-11ea-8555-55028246d1b3.png">

----

I've not yet gotten the website running locally to verify that my changes are correct.